### PR TITLE
add KIBANA_TYPE for logstash & kibana images

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,6 @@
 TAG=6.0.0
 ELASTIC_USER=elastic
 ELASTIC_PASSWORD=changeme
-
+# type of docker images, choose between basic, platinum & oss
+ES_TYPE=oss
+KIBANA_TYPE=oss

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   #   ELASTIC_VERSION=6.0.0-beta1 TAG=6.0.0-beta1-3eab5b40 docker-compose up
   #
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:${TAG}
+    image: docker.elastic.co/elasticsearch/elasticsearch-${ES_TYPE}:${TAG}
     container_name: elasticsearch
     environment:
       - 'ELASTIC_PASSWORD=${ELASTIC_PASSWORD}'
@@ -31,7 +31,7 @@ services:
       retries: 5
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:${TAG}
+    image: docker.elastic.co/logstash/logstash-${KIBANA_TYPE}:${TAG}
     container_name: logstash
     volumes:
       - ./pipeline/:/usr/share/logstash/pipeline/
@@ -47,7 +47,7 @@ services:
         condition: service_healthy
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:${TAG}
+    image: docker.elastic.co/kibana/kibana-${KIBANA_TYPE}:${TAG}
     container_name: kibana
     environment:
       - 'ELASTICSEARCH_USERNAME=${ELASTIC_USER}'


### PR DESCRIPTION
Elasticsearch supports 3 types of docker images, platinum, basic & oss
Kibana & Logstash however support x-pack & oss, so distinguishing these images with
ES_TYPE and KIBANA_TYPE so as to mix and match.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>